### PR TITLE
feat: add POST endpoint for favorites API

### DIFF
--- a/src/app/api/favorites/route.js
+++ b/src/app/api/favorites/route.js
@@ -9,3 +9,13 @@ export async function GET() {
   const favorites = await getFavorites();
   return new Response(JSON.stringify(favorites), { status: 200 });
 }
+
+// POST favorite or delete
+export async function POST(request) {
+  const { id } = await request.json();
+  const favorites = await getFavorites();
+
+  await addFavorite(id);
+
+  return new Response(JSON.stringify(favorites), { status: 200 });
+}


### PR DESCRIPTION
This PR adds a POST handler to the /api/favorites route that allows adding a new favorite item by its id.

🔧 Details:
Receives the id of the item from the request body.

Calls the addFavorite utility function to add the item to localStorage.

Responds with the updated list of favorites.

This is the first step toward a fully functional favorites API.